### PR TITLE
Dynamic request manipulation

### DIFF
--- a/com.eclipsesource.restfuse.example/src/com/eclipsesource/restfuse/example/DynamicHeaderTest.java
+++ b/com.eclipsesource.restfuse.example/src/com/eclipsesource/restfuse/example/DynamicHeaderTest.java
@@ -1,0 +1,34 @@
+package com.eclipsesource.restfuse.example;
+
+import static com.eclipsesource.restfuse.Assert.assertOk;
+
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+import com.eclipsesource.restfuse.Destination;
+import com.eclipsesource.restfuse.HttpJUnitRunner;
+import com.eclipsesource.restfuse.Method;
+import com.eclipsesource.restfuse.Response;
+import com.eclipsesource.restfuse.annotation.Context;
+import com.eclipsesource.restfuse.annotation.HttpTest;
+
+@RunWith( HttpJUnitRunner.class )
+public class DynamicHeaderTest {
+	  
+	  @Rule
+	  public Destination restfuse = getDestination();
+	  
+	  @Context
+	  private Response response;
+	  
+	  @HttpTest( method = Method.GET, path = "/" ) 
+	  public void checkRestfuseOnlineStatus() {
+	    assertOk( response );
+	  }
+
+	private Destination getDestination() {
+		Destination destination = new Destination( "http://restfuse.com" );
+		destination.getRequestContext().headers.put("Cookie", "name:value");
+		return destination;
+	}
+}

--- a/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/HttpTestStatement_Test.java
+++ b/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/HttpTestStatement_Test.java
@@ -95,7 +95,7 @@ public class HttpTestStatement_Test {
     when( method.getAnnotation( HttpTest.class ) ).thenReturn( annotation );
     Object target = new Object();
     HttpTestStatement statement 
-      = new HttpTestStatement( base, method, target, "http://localhost", "http://proxy.com", 8080 );
+      = new HttpTestStatement( base, method, target, "http://localhost", "http://proxy.com", 8080, null );
     
     statement.evaluate();
     

--- a/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/HttpTestStatement_Test.java
+++ b/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/HttpTestStatement_Test.java
@@ -95,7 +95,7 @@ public class HttpTestStatement_Test {
     when( method.getAnnotation( HttpTest.class ) ).thenReturn( annotation );
     Object target = new Object();
     HttpTestStatement statement 
-      = new HttpTestStatement( base, method, target, "http://localhost", "http://proxy.com", 8080 );
+      = new HttpTestStatement( base, method, target, "http://localhost", "http://proxy.com", 8080, null );
     
     statement.evaluate();
     
@@ -103,6 +103,14 @@ public class HttpTestStatement_Test {
     assertNull( System.getProperty( HttpTestStatement.HTTP_PROXY_PORT ) );
   }
 
+  
+//  @Test
+//  @HttpTest( method = Method.GET, path = "/", headers = { @Header(name="Cookie", value="test=value")} )
+//  public void testRequestContextHeaders() {
+//	  	  
+//	  assertEquals(1, response.getHeaders().size());
+//  }
+  
   private HttpTest createAnnotation() {
     HttpTest annotation = new HttpTest() {
       

--- a/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestConfiguration_Test.java
+++ b/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestConfiguration_Test.java
@@ -17,14 +17,10 @@ import static org.mockito.Mockito.mock;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestResult;
-
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;

--- a/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestContextConfiguration_Test.java
+++ b/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestContextConfiguration_Test.java
@@ -33,6 +33,7 @@ import com.eclipsesource.restfuse.Method;
 import com.eclipsesource.restfuse.Request;
 import com.eclipsesource.restfuse.Response;
 import com.eclipsesource.restfuse.annotation.Authentication;
+import com.eclipsesource.restfuse.annotation.Header;
 import com.eclipsesource.restfuse.annotation.HttpTest;
 import com.eclipsesource.restfuse.internal.callback.CallbackSerlvet;
 import com.eclipsesource.restfuse.internal.callback.CallbackStatement;
@@ -80,7 +81,7 @@ private static final int TIMEOUT = 10;
 	@Override
 	public Response post( Request request ) {
   	  // store request to be used in test case
-	  this.request = request;
+	  this.request = request;	  
       return super.post( request );
     }    
   }
@@ -107,6 +108,25 @@ private static final int TIMEOUT = 10;
       Map<String, List<String>> headers = resource.request.getHeaders();
       assertTrue( headers.containsKey( "Authorization" ) );
       assertEquals( "value", headers.get( "test" ).get( 0 ) );
+      assertEquals( MediaType.TEXT_PLAIN, resource.request.getType() );
+  }
+  
+  @Test
+  @HttpTest( 
+    method = Method.POST,
+    path = "/",
+    authentications = { @Authentication( type = AuthenticationType.BASIC, user = "test", password = "pass" ) },
+    type = MediaType.TEXT_PLAIN,
+    content = "test",
+    headers = { @Header( name = "test", value = "new-value" ) }
+  )
+  public void overrideHeaderTestMethod() {	
+      assertEquals( "test", resource.request.getBody() );
+      Map<String, List<String>> headers = resource.request.getHeaders();
+      assertTrue( headers.containsKey( "Authorization" ) );
+      
+      assertEquals( "value", headers.get( "new-value" ).get( 0 ) );
+      
       assertEquals( MediaType.TEXT_PLAIN, resource.request.getType() );
   }
 

--- a/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestContextConfiguration_Test.java
+++ b/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestContextConfiguration_Test.java
@@ -43,7 +43,7 @@ import com.eclipsesource.restfuse.internal.callback.CallbackSerlvet;
 import com.eclipsesource.restfuse.internal.callback.CallbackStatement;
 
 
-public class RequestConfiguration_Test {
+public class RequestContextConfiguration_Test {
   
 
 private static final int TIMEOUT = 10;
@@ -54,7 +54,7 @@ private static final int TIMEOUT = 10;
   
   @BeforeClass
   public static void setUp() throws Exception {
-    server = new Server( 10043 );
+    server = new Server( 10045 );
     Context context = new Context( server, "/", Context.SESSIONS );
     CallbackStatement statement = mock( CallbackStatement.class );
     
@@ -91,12 +91,17 @@ private static final int TIMEOUT = 10;
   }
   
   @Rule
-  public Destination destination = new Destination( "http://localhost:10043/test" );  
+  public Destination destination = getDestination();  
     
+  private Destination getDestination() {
+	  Destination destination = new Destination( "http://localhost:10045/test" );
+	  destination.getRequestContext().headers.put("test", "value");
+	  return destination;
+  }
+  
   @Test
   @HttpTest( 
-    method = Method.POST, 
-    headers = { @Header( name = "test", value = "value" ) }, 
+    method = Method.POST,
     path = "/",
     authentications = { @Authentication( type = AuthenticationType.BASIC, user = "test", password = "pass" ) },
     type = MediaType.TEXT_PLAIN,
@@ -108,5 +113,6 @@ private static final int TIMEOUT = 10;
       assertTrue( headers.containsKey( "Authorization" ) );
       assertEquals( "value", headers.get( "test" ).get( 0 ) );
       assertEquals( MediaType.TEXT_PLAIN, resource.request.getType() );
-  }  
+  }
+
 }

--- a/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestContextConfiguration_Test.java
+++ b/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestContextConfiguration_Test.java
@@ -125,8 +125,8 @@ private static final int TIMEOUT = 10;
       Map<String, List<String>> headers = resource.request.getHeaders();
       assertTrue( headers.containsKey( "Authorization" ) );
       
-      assertEquals( "value", headers.get( "new-value" ).get( 0 ) );
-      
+      assertEquals( "value,new-value", headers.get( "test" ).get( 0 ) );
+            
       assertEquals( MediaType.TEXT_PLAIN, resource.request.getType() );
   }
 

--- a/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestContextConfiguration_Test.java
+++ b/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/internal/RequestContextConfiguration_Test.java
@@ -17,14 +17,10 @@ import static org.mockito.Mockito.mock;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestResult;
-
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.Context;
 import org.mortbay.jetty.servlet.ServletHolder;
@@ -37,7 +33,6 @@ import com.eclipsesource.restfuse.Method;
 import com.eclipsesource.restfuse.Request;
 import com.eclipsesource.restfuse.Response;
 import com.eclipsesource.restfuse.annotation.Authentication;
-import com.eclipsesource.restfuse.annotation.Header;
 import com.eclipsesource.restfuse.annotation.HttpTest;
 import com.eclipsesource.restfuse.internal.callback.CallbackSerlvet;
 import com.eclipsesource.restfuse.internal.callback.CallbackStatement;

--- a/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/test/AllRestfustTestSuite.java
+++ b/com.eclipsesource.restfuse.test/src/com/eclipsesource/restfuse/test/AllRestfustTestSuite.java
@@ -25,6 +25,7 @@ import com.eclipsesource.restfuse.internal.AuthenticationInfo_Test;
 import com.eclipsesource.restfuse.internal.HttpTestStatement_Test;
 import com.eclipsesource.restfuse.internal.InternalRequest_Test;
 import com.eclipsesource.restfuse.internal.RequestConfiguration_Test;
+import com.eclipsesource.restfuse.internal.RequestContextConfiguration_Test;
 import com.eclipsesource.restfuse.internal.RequestImpl_Test;
 import com.eclipsesource.restfuse.internal.ResponseImpl_Test;
 import com.eclipsesource.restfuse.internal.callback.CallbackServer_Test;
@@ -45,6 +46,7 @@ import com.eclipsesource.restfuse.internal.poll.PollStateImpl_Test;
   HttpTestStatement_Test.class,
   InternalRequest_Test.class,
   RequestConfiguration_Test.class,
+  RequestContextConfiguration_Test.class,
   RequestImpl_Test.class,
   ResponseImpl_Test.class,
   PollStateImpl_Test.class,

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/Destination.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/Destination.java
@@ -59,6 +59,8 @@ public class Destination implements MethodRule {
   private final String baseUrl;
   private String proxyHost;
   private int proxyPort;
+  
+  private RequestContext context;
 
   /**
    * <p>Constructs a new <code>Destination</code> object. An url is needed as parameter which will
@@ -69,9 +71,11 @@ public class Destination implements MethodRule {
    * @throws IllegalArgumentException Will be thrown when the <code>baseUrl</code> is null or 
    * not a valid url.
    */
-  public Destination( String baseUrl ) {
+  public Destination( String baseUrl) {
     checkBaseUrl( baseUrl );
     this.baseUrl = baseUrl;
+    
+    context = new RequestContext();
   }
   
   /**
@@ -92,8 +96,19 @@ public class Destination implements MethodRule {
     this( baseUrl );
     this.proxyHost = proxyHost;
     this.proxyPort = proxyPort;
+    
+    context = new RequestContext();
   }
 
+  /**
+   * Access to context to define additional request properties at runtime
+   * @return context to be manipulated
+   */
+  public RequestContext getRequestContext()
+  {
+    return context;
+  }
+  
   private void checkBaseUrl( String baseUrl ) {
     if( baseUrl == null ) {
       throw new IllegalArgumentException( "baseUrl must not be null" );
@@ -113,7 +128,7 @@ public class Destination implements MethodRule {
   {
     Statement result;
     if( hasAnnotation( method ) ) {
-      requestStatement = new HttpTestStatement( base, method, target, baseUrl, proxyHost, proxyPort );
+      requestStatement = new HttpTestStatement( base, method, target, baseUrl, proxyHost, proxyPort, context );
       result = requestStatement;
     } else {
       result = base;

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/RequestContext.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/RequestContext.java
@@ -1,0 +1,20 @@
+package com.eclipsesource.restfuse;
+
+import java.util.HashMap;
+
+/**
+ * Request context hold additional data to be added to the request before execution
+ * like headers (cookies), authorization, ...  
+ */
+public class RequestContext {
+  
+  /**
+   * Name value collection of headers
+   */
+  public HashMap<String, String> headers;
+  
+  public RequestContext()
+  {
+    headers = new HashMap<String, String>();
+  }  
+}

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/RequestContext.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/RequestContext.java
@@ -12,8 +12,8 @@ public class RequestContext {
    * Name value collection of headers
    */
   public HashMap<String, String> headers;
-  
-  public Object body;
+
+  // TODO: Add additional properties to be used at test runtime
   
   public RequestContext()
   {

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/RequestContext.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/RequestContext.java
@@ -13,6 +13,8 @@ public class RequestContext {
    */
   public HashMap<String, String> headers;
   
+  public Object body;
+  
   public RequestContext()
   {
     headers = new HashMap<String, String>();

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/internal/HttpTestStatement.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/internal/HttpTestStatement.java
@@ -54,8 +54,7 @@ public class HttpTestStatement extends Statement {
     this.target = target;
     this.baseUrl = baseUrl;
     this.proxyHost = proxyHost;
-    this.proxyPort = proxyPort;
-    
+    this.proxyPort = proxyPort;    
     this.context = context;
   }
 

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/internal/HttpTestStatement.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/internal/HttpTestStatement.java
@@ -17,6 +17,7 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
 import com.eclipsesource.restfuse.Method;
+import com.eclipsesource.restfuse.RequestContext;
 import com.eclipsesource.restfuse.Response;
 import com.eclipsesource.restfuse.annotation.Callback;
 import com.eclipsesource.restfuse.annotation.Context;
@@ -38,13 +39,15 @@ public class HttpTestStatement extends Statement {
   private final String baseUrl;
   private final String proxyHost;
   private final int proxyPort;
+  private final RequestContext context;
   
   public HttpTestStatement( Statement base, 
                             FrameworkMethod method, 
                             Object target, 
                             String baseUrl, 
                             String proxyHost, 
-                            int proxyPort ) 
+                            int proxyPort,
+                            RequestContext context) 
   {
     this.base = base;
     this.method = method;
@@ -52,6 +55,8 @@ public class HttpTestStatement extends Statement {
     this.baseUrl = baseUrl;
     this.proxyHost = proxyHost;
     this.proxyPort = proxyPort;
+    
+    this.context = context;
   }
 
   @Override
@@ -105,7 +110,7 @@ public class HttpTestStatement extends Statement {
 
   private InternalRequest buildRequest() {
     RequestConfiguration requestConfiguration = new RequestConfiguration( baseUrl, method, target );
-    return requestConfiguration.createRequest();
+    return requestConfiguration.createRequest(context);
   }
 
   private ClientResponse callService( InternalRequest request ) {

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/internal/RequestConfiguration.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/internal/RequestConfiguration.java
@@ -66,7 +66,7 @@ public class RequestConfiguration {
   private void addHeader( HttpTest call, InternalRequest request, RequestContext context ) {
     
     // add headers from context if available
-    if( context.headers.size() > 0 ) {
+    if(context != null && context.headers.size() > 0 ) {
       for( String name : context.headers.keySet() )
         request.addHeader( name, context.headers.get( name ) );
     }

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/internal/RequestConfiguration.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/internal/RequestConfiguration.java
@@ -37,14 +37,14 @@ public class RequestConfiguration {
   public InternalRequest createRequest( RequestContext context ) {
     HttpTest call = method.getAnnotation( HttpTest.class );
     InternalRequest request = new InternalRequest( combineUrlAndPath( baseUrl, call.path() ) );
-    addAuthentication( call, request );
-    addContentType( call, request );
+    addAuthentication( call, request);
+    addContentType( call, request);
     addHeader( call, request, context );
-    addBody( call, request );
+    addBody( call, request);
     return request;
   }
 
-  private void addAuthentication( HttpTest call, InternalRequest request ) {
+  private void addAuthentication( HttpTest call, InternalRequest request) {
     Authentication[] authentications = call.authentications();
     if( authentications != null ) {
       for( Authentication authentication : authentications ) {
@@ -56,7 +56,7 @@ public class RequestConfiguration {
     }
   }
 
-  private void addContentType( HttpTest call, InternalRequest request ) {
+  private void addContentType( HttpTest call, InternalRequest request) {
     MediaType contentType = call.type();
     if( contentType != null ) {
       request.setContentType( contentType.getMimeType() );
@@ -66,7 +66,7 @@ public class RequestConfiguration {
   private void addHeader( HttpTest call, InternalRequest request, RequestContext context ) {
     
     // add headers from context if available
-    if( context.headers.size() > 0 ) {
+    if(context != null && context.headers.size() > 0 ) {
       for( String name : context.headers.keySet() )
         request.addHeader( name, context.headers.get( name ) );
     }
@@ -80,7 +80,7 @@ public class RequestConfiguration {
     }
   }
 
-  private void addBody( HttpTest test, InternalRequest request ) {
+  private void addBody( HttpTest test, InternalRequest request) {
     if( !test.file().equals( "" ) ) {
       request.setContent( getFileStream( test.file() ) );
     } else if( !test.content().equals( "" ) ) {


### PR DESCRIPTION
I have created an additional RequestContext, which can be manipulated before the request is executed.

I needed this because an authorization token must be retrieved and set prior to any REST API call. 

As the Destination object is created upon each test call I have added a RequestContext property to this class, which is then used to insert header into the request prior execution.
The Destination object can be instantiated with a method call so It's the perfect place for my purpose.

Of course we can add additional features to the RequestContext (for now there is only a name value collection of headers present).

Please review and consider this (or a similar) solution.
