### PR TITLE
Add ability to reset RequestContext on a Destination

### DIFF
--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/Destination.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/Destination.java
@@ -76,7 +76,7 @@ public class Destination implements TestRule {
     checkTestObject( testObject );
     this.testObject = testObject;
     this.baseUrl = baseUrl;
-    this.context = new RequestContext();
+    resetRequestContext();
   }
   
   /**
@@ -97,7 +97,7 @@ public class Destination implements TestRule {
     this( testObject, baseUrl );
     this.proxyHost = proxyHost;
     this.proxyPort = proxyPort;
-    this.context = new RequestContext();
+    resetRequestContext();
   }
 
   /**
@@ -106,6 +106,13 @@ public class Destination implements TestRule {
    */
   public RequestContext getRequestContext() {
     return context;
+  }
+  
+  /**
+   * Discards and creates a new {@link RequestContext} for this {@link Destination}.
+   */
+  public void resetRequestContext(){
+    this.context = new RequestContext();
   }
   
   private void checkBaseUrl( String baseUrl ) {


### PR DESCRIPTION
Allows the tester to reset the RequestContext within a test suite.

This is a work around solution for https://github.com/eclipsesource/restfuse/issues/24 until the grander "Test Method Chaining" can be implemented.
