### PR TITLE
execute @Before annotated methods before REST requests

### DIFF
--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/HttpJUnitRunner.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/HttpJUnitRunner.java
@@ -1,12 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2011 EclipseSource and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
+ * Copyright (c) 2011 EclipseSource and others. All rights reserved. This program and the
+ * accompanying materials are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Holger Staudacher - initial API and implementation
+ * http://www.eclipse.org/legal/epl-v10.html Contributors: Holger Staudacher - initial API and
+ * implementation
  ******************************************************************************/
 package com.eclipsesource.restfuse;
 
@@ -15,30 +12,43 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.rules.RunRules;
+import org.junit.rules.TestRule;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
 
+import com.eclipsesource.restfuse.annotation.HttpConfig;
 import com.eclipsesource.restfuse.annotation.HttpTest;
 
-
 /**
- * <p>The <code>HttpJUnitRunner</code> can be used in your TestCase to avoid the double annotation
- * of test methods with the <code>Test</code> and </code>{@link HttpTest}</code> annotation. The
- * runner detects all <code>{@link HttpTest}</code> annotated methods and executes them as normal
- * JUnit test methods.</p>
+ * <p>
+ * The <code>HttpJUnitRunner</code> can be used in your TestCase to avoid the double annotation of
+ * test methods with the <code>Test</code> and </code>{@link HttpTest}</code> annotation. The runner
+ * detects all <code>{@link HttpTest}</code> annotated methods and executes them as normal JUnit
+ * test methods.
+ * </p>
  */
 public class HttpJUnitRunner extends BlockJUnit4ClassRunner {
 
   public HttpJUnitRunner( Class<?> klass ) throws InitializationError {
     super( klass );
   }
-  
+
+  RuleStrategy getRuleStrategy( Object test ) {
+    HttpConfig annotation = test.getClass().getAnnotation( HttpConfig.class );
+    if( annotation == null ) {
+      return RuleStrategy.DEFAULT;
+    }
+    return annotation.ruleStrategy();
+  }
+
   @Override
   protected List<FrameworkMethod> computeTestMethods() {
     ArrayList<FrameworkMethod> result = new ArrayList<FrameworkMethod>();
-    result.addAll( getTestClass().getAnnotatedMethods(HttpTest.class) );
-    List<FrameworkMethod> testAnnotatedMethods = getTestClass().getAnnotatedMethods(Test.class);
+    result.addAll( getTestClass().getAnnotatedMethods( HttpTest.class ) );
+    List<FrameworkMethod> testAnnotatedMethods = getTestClass().getAnnotatedMethods( Test.class );
     for( FrameworkMethod method : testAnnotatedMethods ) {
       if( !result.contains( method ) ) {
         result.add( method );
@@ -47,5 +57,44 @@ public class HttpJUnitRunner extends BlockJUnit4ClassRunner {
     Collections.sort( result, new HttpOrderComparator() );
     return result;
   }
-  
+
+  @Override
+  protected Statement methodInvoker( FrameworkMethod method, Object test ) {
+    if( getRuleStrategy( test ) == RuleStrategy.HTTP_CALL_AFTER_BEFORE ) {
+      Statement methodInvoker = super.methodInvoker( method, test );
+      return withDestinationRules( method, test, methodInvoker );
+    }
+    return super.methodInvoker( method, test );
+  }
+
+  @Override
+  protected List<TestRule> getTestRules( Object target ) {
+    if( getRuleStrategy( target ) == RuleStrategy.HTTP_CALL_AFTER_BEFORE ) {
+      List<TestRule> testRules = super.getTestRules( target );
+      List<TestRule> nonDestinationRules = new ArrayList<TestRule>( testRules );
+      for( TestRule t : testRules ) {
+        if( t instanceof Destination ) {
+          nonDestinationRules.remove( t );
+        }
+      }
+      return nonDestinationRules;
+    }
+    return super.getTestRules( target );
+  }
+
+  protected List<TestRule> getDestinationRules( Object target ) {
+    List<TestRule> testRules = super.getTestRules( target );
+    List<TestRule> destinationRules = new ArrayList<TestRule>();
+    for( TestRule t : testRules ) {
+      if( t instanceof Destination ) {
+        destinationRules.add( t );
+      }
+    }
+    return destinationRules;
+  }
+
+  private Statement withDestinationRules( FrameworkMethod method, Object target, Statement statement )
+  {
+    return new RunRules( statement, getDestinationRules( target ), describeChild( method ) );
+  }
 }

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/RuleStrategy.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/RuleStrategy.java
@@ -1,0 +1,16 @@
+package com.eclipsesource.restfuse;
+
+
+public enum RuleStrategy {
+  /**
+   * default behaviour:
+   * <p>destination rule is executed as junit does</p>
+   */
+  DEFAULT,
+  /**
+   * default behaviour:
+   * <p>destination rule is wrapped around the actual method invocation.
+   * This means that <code>@Before</code> methods are executed before the rest service is called</p>
+   */
+  HTTP_CALL_AFTER_BEFORE
+}

--- a/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/annotation/HttpConfig.java
+++ b/com.eclipsesource.restfuse/src/com/eclipsesource/restfuse/annotation/HttpConfig.java
@@ -1,0 +1,14 @@
+package com.eclipsesource.restfuse.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.eclipsesource.restfuse.RuleStrategy;
+
+@Retention( RetentionPolicy.RUNTIME )
+@Target( { ElementType.TYPE } )
+public @interface HttpConfig {
+  RuleStrategy ruleStrategy() default RuleStrategy.DEFAULT;
+}


### PR DESCRIPTION
patched HttpJUnitRunner to support this
added @HttpConfig annotation and RuleStrategy enum to configure behavior
default behavior is unchanged

example:

``` java
@RunWith(HttpJUnitRunner.class)
@HttpConfig(ruleStrategy=RuleStrategy.HTTP_CALL_AFTER_BEFORE)
public class MyTest {
    @Rule
    public Destination destination = new Destination(this, "http://localhost:" + System.getProperty( "org.osgi.service.http.port" ));

    @Context
    private Response response;

    @Before
    public void before() {
        System.err.println("Test#before()");
        Bundle bundle = FrameworkUtil.getBundle(Test.class);
        BundleContext bundleContext = bundle.getBundleContext();
        ServiceReference<WebService> serviceReference = bundleContext.getServiceReference(WebService.class);
        WebService service = bundleContext.getService(serviceReference);
        service.setName("Foo");
    }

    @org.junit.Test
    @HttpTest(method=Method.GET, path="/services/hello")
    public void testServiceCall() {
        System.err.println("Test#testServiceCall()");
        assertOk(response);
        assertEquals("Hello Foo", response.getBody());
    }
}


@Path("/")
public class WebService {

    private String name = "World";

    @GET
    @Path("/hello")
    public String helloWorld() {
        System.err.println("WebService#helloWorld()");
        return "Hello " + name;
    }

    public void setName(String name) {
        this.name = name;
    }
}
```
